### PR TITLE
feat use jdk from eclipse-temurin

### DIFF
--- a/sonic-server/Dockerfile
+++ b/sonic-server/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:17-jdk AS builder
+FROM eclipse-temurin:17-jdk AS builder
 
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
基础镜像由已废弃的openjdk更换为eclipse-temurin
此外，由于eclipse-temurin还包含arm64的镜像，因此还能额外获容器部署方式在例如m1芯片的mac或其他arm64架构的机器上也可用的新特性